### PR TITLE
Fix armor slot

### DIFF
--- a/src/alvin0319/CustomItemLoader/item/properties/CustomItemProperties.php
+++ b/src/alvin0319/CustomItemLoader/item/properties/CustomItemProperties.php
@@ -427,6 +427,7 @@ final class CustomItemProperties{
 			"boots" => ArmorInventory::SLOT_FEET,
 			default => throw new InvalidArgumentException("Unknown armor slot $armorSlot given.")
 		};
+		$this->setArmorSlot($armor_slot_int);
 
 		static $acceptedArmorValues = ["gold", "none", "leather", "chain", "iron", "diamond", "elytra", "turtle", "netherite"];
 


### PR DESCRIPTION
I noticed that when you equip armor(right click on air) the item is equipped in the head slot, even if it's boots, chestplate or leggings