### PR TITLE
Log exception when a custom items failed to load

### DIFF
--- a/src/alvin0319/CustomItemLoader/CustomItemLoader.php
+++ b/src/alvin0319/CustomItemLoader/CustomItemLoader.php
@@ -51,6 +51,7 @@ class CustomItemLoader extends PluginBase{
 			CustomItemManager::getInstance()->registerDefaultItems($this->getConfig()->get("items", []));
 		}catch(\Throwable $e){
 			$this->getLogger()->critical("Failed to load custom items: " . $e->getMessage() . ", disabling plugin to prevent any unintended behaviour...");
+			$this->getLogger()->logException($e);
 			$this->getServer()->getPluginManager()->disablePlugin($this);
 			return;
 		}


### PR DESCRIPTION
Currently, if an error occurs while loading, the stack trace of the error is not displayed.
This creates a barrier for developers to see error details.
However, if this is the intended behavior to not pollute the console, then this is closed. sorry.